### PR TITLE
feat: use Laravel's built-in health route

### DIFF
--- a/template/docker-compose.prod.yml
+++ b/template/docker-compose.prod.yml
@@ -34,6 +34,7 @@ services:
       PHP_OPCACHE_ENABLE: "1"
       AUTORUN_ENABLED: "true" # 👈 Remove this line if you don't want Laravel Automations
       APP_ENV: "${SPIN_DEPLOYMENT_ENVIRONMENT}" # 👈 Remove this if you're not using `spin deploy`
+      HEALTHCHECK_PATH: "/up" # Use Laravel's built-in health route
     networks:
       - web-public
     volumes:
@@ -66,7 +67,7 @@ services:
         - "traefik.http.services.my-php-app.loadbalancer.server.port=8080"
         - "traefik.http.services.my-php-app.loadbalancer.server.scheme=http"
         # Health check
-        - "traefik.http.services.my-php-app.loadbalancer.healthcheck.path=/healthcheck"
+        - "traefik.http.services.my-php-app.loadbalancer.healthcheck.path=/up"
         - "traefik.http.services.my-php-app.loadbalancer.healthcheck.interval=30s"
         - "traefik.http.services.my-php-app.loadbalancer.healthcheck.timeout=5s"
         - "traefik.http.services.my-php-app.loadbalancer.healthcheck.scheme=http"


### PR DESCRIPTION
See #11 for previous context.

https://serversideup.net/open-source/docker-php/docs/guide/using-healthchecks-with-laravel#changing-the-health-check-path
https://laravel.com/docs/11.x/deployment#the-health-route

> This only validates that FPM-NGINX or FPM-APACHE are running and ready to accept connections. It does not validate that Laravel is running or healthy.
>
> If you are using Laravel, [modern versions of Laravel will ship with a /up route](https://laravel.com/docs/11.x/deployment#the-health-route) that you can use to validate that Laravel is running and healthy.

So, this PR aims to change the default to use Laravel's built-in health route, to have a better healthcheck.